### PR TITLE
Fix README.md to not use shadow variable `DB` in init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ import (
 var DB *crud.DB
 
 func init () {
-  DB, err := crud.Connect("mysql", os.Getenv("DATABASE_URL"))
-  err := DB.Ping()
+  var err error
+  DB, err = crud.Connect("mysql", os.Getenv("DATABASE_URL"))
+  err = DB.Ping()
 }
 ```
 


### PR DESCRIPTION
In README the `DB` variable in `init()` masks the global `DB` and thus the subsequent examples panics by the global **nil** `DB`. It's confusing, so I suggest not to use `:=`.